### PR TITLE
Update send command used in sys-setup

### DIFF
--- a/recipes-support/sys-setup/sys-setup/zsend.sh
+++ b/recipes-support/sys-setup/sys-setup/zsend.sh
@@ -7,4 +7,4 @@ BAUDRATE=115200
 #BAUDRATE=57600
 
 stty -F $DEV $BAUDRATE
-sz /data/caam/enckey.bb >$DEV <$DEV
+sx /data/caam/enckey.bb >$DEV <$DEV


### PR DESCRIPTION
This pull request resolves issue #1 by changing the send command used in `sys-setup` from `sz` to `sx`.