### PR TITLE
Update u-boot imx8mmevk patches for kirkstone

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/imx8mmevk/0001-HAB-encrypted-boot.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mmevk/0001-HAB-encrypted-boot.patch
@@ -1,23 +1,23 @@
-From c6572ad2b5d4800b7aed06625232b89ea2161352 Mon Sep 17 00:00:00 2001
-From: Sivaprasad <sivaprasad.sv@jasmin-infotech.com>
-Date: Fri, 18 Mar 2022 14:17:53 +0530
-Subject: [PATCH] HAB-encrypted-boot
+From 9f625d47c96a20c781a9114966076ce07da88c33 Mon Sep 17 00:00:00 2001
+From: RJ Fendricks <robert.fendricks@bgnetworks.net>
+Date: Fri, 19 Aug 2022 15:45:56 -0400
+Subject: [PATCH] HAB encrypted boot
 
 ---
  configs/imx8mm_evk_defconfig | 6 ++++++
  1 file changed, 6 insertions(+)
 
 diff --git a/configs/imx8mm_evk_defconfig b/configs/imx8mm_evk_defconfig
-index 521ba35659..ab33734aff 100644
+index ca1c4a268a..feb5e53eff 100644
 --- a/configs/imx8mm_evk_defconfig
 +++ b/configs/imx8mm_evk_defconfig
-@@ -180,3 +180,9 @@ CONFIG_EFI_RUNTIME_UPDATE_CAPSULE=y
- CONFIG_EFI_CAPSULE_ON_DISK=y
- CONFIG_EFI_CAPSULE_FIRMWARE_RAW=y
- CONFIG_EFI_SECURE_BOOT=y
+@@ -206,3 +206,9 @@ CONFIG_TEE=y
+ CONFIG_EFI_ESRT=y
+ CONFIG_EFI_HAVE_CAPSULE_UPDATE=y
+ CONFIG_FIT_SIGNATURE=y
 +
++CONFIG_EFI_SECURE_BOOT=y
 +CONFIG_IMX_HAB=y
 +CONFIG_FAT_WRITE=y
 +CONFIG_CMD_DEKBLOB=y
 +CONFIG_IMX_OPTEE_DEK_ENCAP=y
-+CONFIG_CMD_PRIBLOB=y

--- a/recipes-bsp/u-boot/u-boot-imx/imx8mmevk/0002-Add-fastboot-commands.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/imx8mmevk/0002-Add-fastboot-commands.patch
@@ -1,21 +1,14 @@
-From bb02553b3077c9ace3346d3b2693374ff785a835 Mon Sep 17 00:00:00 2001
-From: danie007 <daniel.selvan@jasmin-infotech.com>
-Date: Thu, 17 Jun 2021 13:56:35 +0530
+From 91a54aa1438bcf7923ad6d5553dcc6c0c1b2f91b Mon Sep 17 00:00:00 2001
+From: RJ Fendricks <robert.fendricks@bgnetworks.net>
+Date: Fri, 19 Aug 2022 15:46:42 -0400
 Subject: [PATCH] Add fastboot commands
 
-Fastboot commands,
-  1. read-dekblob
-  2. read-fuses
-  3. read-srktbl
-are added to automate the encryption with "UUU" tool
-
-Signed-off-by: danie007 <daniel.selvan@jasmin-infotech.com>
 ---
  drivers/fastboot/fb_fsl/fb_fsl_getvar.c | 140 +++++++++++++++++++++++-
  1 file changed, 135 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/fastboot/fb_fsl/fb_fsl_getvar.c b/drivers/fastboot/fb_fsl/fb_fsl_getvar.c
-index 457b5ae123..7df62d6ed6 100644
+index 49caf3d7eb..3852419db8 100644
 --- a/drivers/fastboot/fb_fsl/fb_fsl_getvar.c
 +++ b/drivers/fastboot/fb_fsl/fb_fsl_getvar.c
 @@ -1,6 +1,9 @@


### PR DESCRIPTION
The patches being applied to the imx8mmevk u-boot need to be updated to match the newer Kirkstone u-boot.