### PR TITLE
Fixed terminal closure on script failure

### DIFF
--- a/scripts/setup-essa.sh
+++ b/scripts/setup-essa.sh
@@ -17,7 +17,7 @@ LOCAL_CONF_APPEND="local-${MACHINE}.conf.append"
 # If NXP script failed, halt
 (($? != 0)) && {
     echo "init script failure"
-    exit 1
+    return 1
 }
 
 echo "" >>conf/bblayers.conf


### PR DESCRIPTION
This PR fixes #6 as `exit` is replaced with `return` to properly exit script without closing the terminal

---

CC @tkmozhi 
